### PR TITLE
fix: skip variants with non-ACTG bases in alt seq

### DIFF
--- a/pangolin/utils.py
+++ b/pangolin/utils.py
@@ -209,6 +209,8 @@ def prepare_variant(
         or (len(ref) != 1 and len(alt) != 1 and len(ref) != len(alt))
     ):
         skip_message = "Variant format not supported."
+    elif not all(base in 'ACTG' for base in alt):
+        skip_message = "Unsupported bases in alt seq."
     elif len(ref) > 2 * distance:
         skip_message = "Deletion too large"
 

--- a/pangolin/utils.py
+++ b/pangolin/utils.py
@@ -205,7 +205,6 @@ def prepare_variant(
     seq_time = time.time()
     if (
         len(set("ACGT").intersection(set(ref))) == 0
-        or len(set("ACGT").intersection(set(alt))) == 0
         or (len(ref) != 1 and len(alt) != 1 and len(ref) != len(alt))
     ):
         skip_message = "Variant format not supported."

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,6 +33,34 @@ def test_unsupported_ref_seq(seq, expected):
     assert skip_message_contains_text == expected
 
 
+@pytest.mark.parametrize(
+    "seq, expected_to_skip",
+    [
+        ("ACTGV", True),
+        ("ACTG", False),
+        ("AAAA", False),
+        ("AAUAA", True),
+        ("U", True),
+        ("N", True),
+        ("ACTN", True),
+        ("ALINE", True),
+    ],
+)
+def test_unsupported_alt_seq(seq, expected_to_skip):
+    variant = Variant(lnum=1, chr="chr1", pos=100, ref="C", alt=seq)
+    # Mock out the fasta seq so it returns the passed in sequence
+    fasta = MagicMock()
+    fasta.keys = MagicMock(return_value=[variant.chr])
+    seq_obj = namedtuple("RefSeq", "seq")
+    fasta[variant.chr].__getitem__ = MagicMock(return_value=seq_obj("CCCC"))
+
+    prepped_variant, _ = prepare_variant(variant, None, fasta, 500)
+    skip_message_contains_text = (
+        prepped_variant.skip_message == "Unsupported bases in alt seq."
+    )
+    assert skip_message_contains_text == expected_to_skip
+
+
 @pytest.mark.parametrize("genes, gain, loss, expected_score", [
     pytest.param(
         {"GENE1": []},


### PR DESCRIPTION
This PR skips variants with non-ACTG bases in the alt sequence